### PR TITLE
Make Sleeping Spots inherit from Vanilla base

### DIFF
--- a/1.3/Defs/PolyamoryDefs.xml
+++ b/1.3/Defs/PolyamoryDefs.xml
@@ -4,86 +4,28 @@
 
   <!--============================== Polyamory Beds (Vanilla Edition) ==============================-->
   
-  <ThingDef ParentName="BuildingBase">
+  <ThingDef ParentName="SleepingSpotBase">
     <defName>TripleSleepingSpot</defName>
-    <label>triple sleeping spot</label>
+    <label>double sleeping spot</label>
     <description>Designates a spot on the ground where three people should sleep together. Not comfortable.</description>
-    <thingClass>Building_Bed</thingClass>
     <graphicData>
       <texPath>Spot3/Spot3</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
       <drawSize>(5,4)</drawSize>
     </graphicData>
-    <altitudeLayer>FloorEmplacement</altitudeLayer>
-    <statBases>
-      <WorkToBuild>0</WorkToBuild>
-      <Comfort>0.4</Comfort>
-      <SurgerySuccessChanceFactor>0.7</SurgerySuccessChanceFactor>
-    </statBases>
-    <scatterableOnMapGen>false</scatterableOnMapGen>
-    <useHitPoints>False</useHitPoints>
     <size>(3,2)</size>
-    <designationCategory>Furniture</designationCategory>
-    <passability>Standable</passability>
-    <drawGUIOverlay>True</drawGUIOverlay>
-    <defaultPlacingRot>South</defaultPlacingRot>
-    <building>
-      <bed_showSleeperBody>True</bed_showSleeperBody>
-      <sowTag>SupportPlantsOnly</sowTag>
-      <canPlaceOverImpassablePlant>false</canPlaceOverImpassablePlant>
-      <ai_chillDestination>false</ai_chillDestination>
-	  <artificialForMeditationPurposes>false</artificialForMeditationPurposes>
-      <buildingTags>
-        <li>Bed</li>
-      </buildingTags>
-    </building>
-    <comps>
-      <li Class="CompProperties_AssignableToPawn">
-        <drawAssignmentOverlay>false</drawAssignmentOverlay>
-        <compClass>CompAssignableToPawn_Bed</compClass>
-      </li>
-    </comps>
   </ThingDef>
   
-  <ThingDef ParentName="BuildingBase">
+  <ThingDef ParentName="SleepingSpotBase">
     <defName>QuadSleepingSpot</defName>
     <label>quadra sleeping spot</label>
     <description>Designates a spot on the ground where four people should sleep together. Not comfortable.</description>
-    <thingClass>Building_Bed</thingClass>
     <graphicData>
       <texPath>Spot4/Spot4</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
       <drawSize>(6,4)</drawSize>
     </graphicData>
-    <altitudeLayer>FloorEmplacement</altitudeLayer>
-    <statBases>
-      <WorkToBuild>0</WorkToBuild>
-      <Comfort>0.4</Comfort>
-      <SurgerySuccessChanceFactor>0.7</SurgerySuccessChanceFactor>
-    </statBases>
-    <scatterableOnMapGen>false</scatterableOnMapGen>
-    <useHitPoints>False</useHitPoints>
     <size>(4,2)</size>
-    <designationCategory>Furniture</designationCategory>
-    <passability>Standable</passability>
-    <drawGUIOverlay>True</drawGUIOverlay>
-    <defaultPlacingRot>South</defaultPlacingRot>
-    <building>
-      <bed_showSleeperBody>True</bed_showSleeperBody>
-      <sowTag>SupportPlantsOnly</sowTag>
-      <canPlaceOverImpassablePlant>false</canPlaceOverImpassablePlant>
-      <ai_chillDestination>false</ai_chillDestination>
-	  <artificialForMeditationPurposes>false</artificialForMeditationPurposes>
-      <buildingTags>
-        <li>Bed</li>
-      </buildingTags>
-    </building>
-    <comps>
-      <li Class="CompProperties_AssignableToPawn">
-        <drawAssignmentOverlay>false</drawAssignmentOverlay>
-        <compClass>CompAssignableToPawn_Bed</compClass>
-      </li>
-    </comps>
   </ThingDef>
   
   <ThingDef ParentName="BedWithQualityBase">

--- a/1.4/Defs/PolyamoryDefs.xml
+++ b/1.4/Defs/PolyamoryDefs.xml
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+
+  <!--============================== Polyamory Beds (Vanilla Edition) ==============================-->
+
+  <!-- Sleeping Spots -->  
+  <ThingDef ParentName="SleepingSpotBase">
+    <defName>TripleSleepingSpot</defName>
+    <label>double sleeping spot</label>
+    <description>Designates a spot on the ground where three people should sleep together. Not comfortable.</description>
+    <graphicData>
+      <texPath>Spot3/Spot3</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <drawSize>(5,4)</drawSize>
+    </graphicData>
+    <size>(3,2)</size>
+  </ThingDef>
+  
+  <ThingDef ParentName="SleepingSpotBase">
+    <defName>QuadSleepingSpot</defName>
+    <label>quadra sleeping spot</label>
+    <description>Designates a spot on the ground where four people should sleep together. Not comfortable.</description>
+    <graphicData>
+      <texPath>Spot4/Spot4</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <drawSize>(6,4)</drawSize>
+    </graphicData>
+    <size>(4,2)</size>
+  </ThingDef>
+
+  <!-- Bedrolls --> 
+  <ThingDef ParentName="BedrollBase">
+    <defName>BedrollTriple</defName>
+    <label>triple bedroll</label>
+    <description>A simple triple-wide bed that lays on the floor, usually made of cloth or leather, often lined with fur. It is lightweight and can be rolled up for easy transport, but it is not quite as comfortable as a typical bed. Caravans can use bedrolls while traveling for better sleep.</description>
+    <graphicData>
+      <texPath>Bedroll3/Bedroll3</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(3,2)</drawSize>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>125</MaxHitPoints>
+      <Mass>6.5</Mass>
+      <WorkToBuild>1600</WorkToBuild>
+    </statBases>
+    <size>(3,2)</size>
+    <costStuffCount>130</costStuffCount>
+  </ThingDef>
+  
+  <ThingDef ParentName="BedrollBase">
+    <defName>BedrollQuad</defName>
+    <label>quadra bedroll</label>
+    <description>A simple quadra-wide bed that lays on the floor, usually made of cloth or leather, often lined with fur. It is lightweight and can be rolled up for easy transport, but it is not quite as comfortable as a typical bed. Caravans can use bedrolls while traveling for better sleep.</description>
+    <graphicData>
+      <texPath>Bedroll4/Bedroll4</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(4,2)</drawSize>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>150</MaxHitPoints>
+      <Mass>8.5</Mass>
+      <WorkToBuild>2100</WorkToBuild>
+    </statBases>
+    <size>(4,2)</size>
+    <costStuffCount>175</costStuffCount>
+  </ThingDef>
+
+  <!-- Regular Beds -->
+
+  <ThingDef ParentName="DoubleBed">
+    <defName>TripleBed</defName>
+    <label>triple bed</label>
+    <description>A simple triple-wide bed that fits three people.</description>
+    <graphicData>
+      <texPath>Bed3/Bed3</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(3.05,2.05)</drawSize>
+      <damageData>
+        <rect>(0,0.05,3,1.95)</rect>
+      </damageData>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>260</MaxHitPoints>
+      <Mass>70</Mass>
+      <Beauty>3</Beauty>
+      <WorkToBuild>2200</WorkToBuild>
+    </statBases>
+    <size>(3,2)</size>
+    <costStuffCount>125</costStuffCount>
+  </ThingDef>
+
+  <ThingDef ParentName="DoubleBed">
+    <defName>QuadBed</defName>
+    <label>quadra bed</label>
+    <description>A simple quadra-wide bed that fits four people.</description>
+    <graphicData>
+      <texPath>Bed4/Bed4</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(4.05,2.05)</drawSize>
+      <damageData>
+        <rect>(0,0.05,4,1.95)</rect>
+      </damageData>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>320</MaxHitPoints>
+      <Mass>90</Mass>
+      <Beauty>4</Beauty>
+      <WorkToBuild>2900</WorkToBuild>
+    </statBases>
+    <size>(4,2)</size>
+    <costStuffCount>165</costStuffCount>
+  </ThingDef>
+  
+  <!-- Royal Beds -->
+
+  <ThingDef ParentName="RoyalBedBase">
+    <defName>TripleRoyalBed</defName>
+    <label>triple royal bed</label>
+    <description>A luxurious gold-inlaid bed fit for the highborn. Very comfy and beautiful, it is a work of art in itself. Fits three.</description>
+    <graphicData>
+      <texPath>RBed3/RBed3</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(3.05,2.05)</drawSize>
+      <damageData>
+        <rect>(0,0.05,3,1.95)</rect>
+      </damageData>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>260</MaxHitPoints>
+      <Mass>90</Mass>
+      <Beauty>80</Beauty>
+      <WorkToBuild>72000</WorkToBuild>
+    </statBases>
+    <size>(3,2)</size>
+    <costStuffCount>150</costStuffCount>
+    <costList>
+      <Gold>75</Gold>
+    </costList>
+  </ThingDef>
+
+  <ThingDef ParentName="RoyalBedBase">
+    <defName>QuadRoyalBed</defName>
+    <label>quadra royal bed</label>
+    <description>A luxurious gold-inlaid bed fit for the highborn. Very comfy and beautiful, it is a work of art in itself. Fits four.</description>
+    <graphicData>
+      <texPath>RBed4/RBed4</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(4.05,2.05)</drawSize>
+      <damageData>
+        <rect>(0,0.05,4,1.95)</rect>
+      </damageData>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>320</MaxHitPoints>
+      <Mass>120</Mass>
+      <Beauty>85</Beauty>
+      <WorkToBuild>94000</WorkToBuild>
+    </statBases>
+    <size>(4,2)</size>
+    <costStuffCount>200</costStuffCount>
+    <costList>
+      <Gold>100</Gold>
+    </costList>
+  </ThingDef>
+ 
+  <ThingDef ParentName="RoyalBedBase">
+    <defName>PentaRoyalBed</defName>
+    <label>penta royal bed</label>
+    <description>A luxurious gold-inlaid bed fit for the highborn. Very comfy and beautiful, it is a work of art in itself. Fits five.</description>
+    <graphicData>
+      <texPath>RBed5/RBed5</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(5.05,2.05)</drawSize>
+      <damageData>
+        <rect>(0,0.05,5,1.95)</rect>
+      </damageData>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>380</MaxHitPoints>
+      <Mass>150</Mass>
+      <Beauty>90</Beauty>
+      <WorkToBuild>116000</WorkToBuild>
+    </statBases>
+    <size>(5,2)</size>
+    <costStuffCount>250</costStuffCount>
+    <costList>
+      <Gold>125</Gold>
+    </costList>
+  </ThingDef>
+
+  <!-- Slab Beds -->
+
+  <ThingDef ParentName="SlabBedBase" MayRequire="Ludeon.RimWorld.Ideology">
+    <defName>SlabTripleBed</defName>
+    <label>slab triple bed</label>
+    <description>A slab of hard material made to sleep on. Slab beds are uncomfortable, but some see their use as a demonstration of moral good. This one is wide enough to fit three people.</description>
+    <graphicData Inherit="False">
+      <texPath>Slab3/Slab3</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(3.05,2.05)</drawSize>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>260</MaxHitPoints>
+      <Mass>70</Mass>
+      <WorkToBuild>1100</WorkToBuild>
+    </statBases>
+    <size>(3,2)</size>
+    <costStuffCount>140</costStuffCount>
+  </ThingDef>
+
+  <ThingDef ParentName="SlabBedBase" MayRequire="Ludeon.RimWorld.Ideology">
+    <defName>SlabQuadBed</defName>
+    <label>slab quad bed</label>
+    <description>A slab of hard material made to sleep on. Slab beds are uncomfortable, but some see their use as a demonstration of moral good. This one is wide enough to fit four people.</description>
+    <graphicData Inherit="False">
+      <texPath>Slab4/Slab4</texPath>
+      <graphicClass>Graphic_Multi</graphicClass>
+      <shaderType>CutoutComplex</shaderType>
+      <drawSize>(4.05,2.05)</drawSize>
+    </graphicData>
+    <statBases>
+      <MaxHitPoints>320</MaxHitPoints>
+      <Mass>90</Mass>
+      <WorkToBuild>1450</WorkToBuild>
+    </statBases>
+    <size>(4,2)</size>
+    <costStuffCount>195</costStuffCount>
+  </ThingDef>
+</Defs>

--- a/1.4/Patches/Generalise_Beds.xml
+++ b/1.4/Patches/Generalise_Beds.xml
@@ -36,7 +36,7 @@
         </li>
         </operations>
     </Operation>
-    <!-- Slab Bed: Use Slab Double Bed as base, set UI order to same as single Slab Bed -->
+    <!-- Slab Bed: Use Slab Double Bed as base, set UI order to same as single Slab Bed. Also add designators to MemeDef. -->
     <Operation Class="PatchOperationSequence" MayRequire="Ludeon.RimWorld.Ideology">
         <operations>
         <li Class="PatchOperationAttributeSet">
@@ -49,5 +49,13 @@
             <value><uiOrder>2030</uiOrder></value>
         </li>
         </operations>
+        <li Class="PatchOperationInsert">
+			<xpath>Defs/MemeDef[defName = "PainIsVirtue"]/addDesignators/li[text()="SlabDoubleBed"]</xpath>
+            <order>Append</order>
+			<value>
+			    <li>SlabTripleBed</li>
+				<li>SlabQuadBed</li>
+			</value>
+			</li>
     </Operation>
 </Patch>

--- a/1.4/Patches/Generalise_Beds.xml
+++ b/1.4/Patches/Generalise_Beds.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
     <!-- Makes some some vanilla beds into bases that can be inherited from. Also sets uiOrder. -->
-    <!-- Order: Sleeping Spots (2000), Bedrolls (2005), Normal Beds (2010), Royal Beds (2015), Other Beds (2020), Slab Beds (2030) -->
+    <!-- Order: Sleeping Spots (2000), Bedrolls (2002), Normal Beds (2004), Royal Beds (2006), Slab Beds (2008), Other Beds (2020) -->
     <!-- Sleeping Spot: Already abstracted in Vanilla, no action needed. -->
     <!-- Bedroll: Use Double Bedroll as base, set UI order -->
     <Operation Class="PatchOperationSequence">
@@ -11,16 +11,28 @@
             <attribute>Name</attribute>
             <value>BedrollBase</value>
         </li>
-        <li Class="PatchOperationReplace">
-            <xpath>/Defs/ThingDef [defName="Bedroll" or defName="BedrollDouble"]/uiOrder/text()</xpath>
-            <value>2005</value>
+        <li Class="PatchOperationRemove">
+            <success>Always</success>
+            <xpath>/Defs/ThingDef [defName="Bedroll" or defName="BedrollDouble"]/uiOrder</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef [defName="Bedroll" or defName="BedrollDouble"]</xpath>
+            <value><uiOrder>2002</uiOrder></value>
         </li>
         </operations>
     </Operation>
-    <!-- Normal Bed: Double Beds are already named for inheritance, just need UI order set same as single bed -->
-    <Operation Class="PatchOperationAdd">
-        <xpath>/Defs/ThingDef [defName="DoubleBed"]</xpath>
-        <value><uiOrder>2010</uiOrder></value>
+    <!-- Normal Bed: Double Beds are already named for inheritance, just set UI order -->
+    <Operation Class="PatchOperationSequence">
+        <operations>
+        <li Class="PatchOperationRemove">
+            <success>Always</success>
+            <xpath>/Defs/ThingDef [defName="Bed" or defName="DoubleBed"]/uiOrder</xpath>
+        </li>
+        <li Class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef [defName="Bed" or defName="DoubleBed"]</xpath>
+            <value><uiOrder>2004</uiOrder></value>
+        </li>
+        </operations>
     </Operation>
     <!-- Royal Bed: Make into base, set UI order -->
     <Operation Class="PatchOperationSequence">
@@ -30,13 +42,17 @@
             <attribute>Name</attribute>
             <value>RoyalBedBase</value>
         </li>
+        <li Class="PatchOperationRemove">
+            <success>Always</success>
+            <xpath>/Defs/ThingDef [defName="RoyalBed"]/uiOrder</xpath>
+        </li>
         <li Class="PatchOperationAdd">
             <xpath>/Defs/ThingDef [defName="RoyalBed"]</xpath>
-            <value><uiOrder>2015</uiOrder></value>
+            <value><uiOrder>2006</uiOrder></value>
         </li>
         </operations>
     </Operation>
-    <!-- Slab Bed: Use Slab Double Bed as base, set UI order to same as single Slab Bed. Also add designators to MemeDef. -->
+    <!-- Slab Bed: Use Slab Double Bed as base, set UI order. Also add designators to MemeDef. -->
     <Operation Class="PatchOperationSequence" MayRequire="Ludeon.RimWorld.Ideology">
         <operations>
         <li Class="PatchOperationAttributeSet">
@@ -44,18 +60,22 @@
             <attribute>Name</attribute>
             <value>SlabBedBase</value>
         </li>
+        <li Class="PatchOperationRemove">
+            <success>Always</success>
+            <xpath>/Defs/ThingDef [defName="SlabBed" or defName="SlabDoubleBed"]/uiOrder</xpath>
+        </li>
         <li Class="PatchOperationAdd">
-            <xpath>/Defs/ThingDef [defName="SlabDoubleBed"]</xpath>
-            <value><uiOrder>2030</uiOrder></value>
+            <xpath>/Defs/ThingDef [defName="SlabBed" or defName="SlabDoubleBed"]</xpath>
+            <value><uiOrder>2008</uiOrder></value>
+        </li>
+        <li Class="PatchOperationInsert">
+            <xpath>Defs/MemeDef[defName = "PainIsVirtue"]/addDesignators/li[text()="SlabDoubleBed"]</xpath>
+            <order>Append</order>
+            <value>
+                <li>SlabTripleBed</li>
+                <li>SlabQuadBed</li>
+            </value>
         </li>
         </operations>
-        <li Class="PatchOperationInsert">
-	    <xpath>Defs/MemeDef[defName = "PainIsVirtue"]/addDesignators/li[text()="SlabDoubleBed"]</xpath>
-            <order>Append</order>
-	    <value>
-	        <li>SlabTripleBed</li>
-		<li>SlabQuadBed</li>
-	    </value>
-	</li>
     </Operation>
 </Patch>

--- a/1.4/Patches/Generalise_Beds.xml
+++ b/1.4/Patches/Generalise_Beds.xml
@@ -50,12 +50,12 @@
         </li>
         </operations>
         <li Class="PatchOperationInsert">
-			<xpath>Defs/MemeDef[defName = "PainIsVirtue"]/addDesignators/li[text()="SlabDoubleBed"]</xpath>
+	    <xpath>Defs/MemeDef[defName = "PainIsVirtue"]/addDesignators/li[text()="SlabDoubleBed"]</xpath>
             <order>Append</order>
-			<value>
-			    <li>SlabTripleBed</li>
-				<li>SlabQuadBed</li>
-			</value>
-			</li>
+	    <value>
+	        <li>SlabTripleBed</li>
+		<li>SlabQuadBed</li>
+	    </value>
+	</li>
     </Operation>
 </Patch>

--- a/1.4/Patches/Generalise_Beds.xml
+++ b/1.4/Patches/Generalise_Beds.xml
@@ -4,47 +4,47 @@
     <!-- Order: Sleeping Spots (2000), Bedrolls (2005), Normal Beds (2010), Royal Beds (2015), Other Beds (2020), Slab Beds (2030) -->
     <!-- Sleeping Spot: Already abstracted in Vanilla, no action needed. -->
     <!-- Bedroll: Use Double Bedroll as base, set UI order -->
-    <Operation class="PatchOperationSequence">
+    <Operation Class="PatchOperationSequence">
         <operations>
-        <li class="PatchOperationAttributeSet">
+        <li Class="PatchOperationAttributeSet">
             <xpath>/Defs/ThingDef [defName="BedrollDouble"]</xpath>
             <attribute>Name</attribute>
             <value>BedrollBase</value>
         </li>
-        <li class="PatchOperationReplace">
+        <li Class="PatchOperationReplace">
             <xpath>/Defs/ThingDef [defName="Bedroll" or defName="BedrollDouble"]/uiOrder/text()</xpath>
             <value>2005</value>
         </li>
         </operations>
     </Operation>
     <!-- Normal Bed: Double Beds are already named for inheritance, just need UI order set same as single bed -->
-    <Operation class="PatchOperationAdd">
+    <Operation Class="PatchOperationAdd">
         <xpath>/Defs/ThingDef [defName="DoubleBed"]</xpath>
         <value><uiOrder>2010</uiOrder></value>
     </Operation>
     <!-- Royal Bed: Make into base, set UI order -->
-    <Operation class="PatchOperationSequence">
+    <Operation Class="PatchOperationSequence">
         <operations>
-        <li class="PatchOperationAttributeSet">
+        <li Class="PatchOperationAttributeSet">
             <xpath>/Defs/ThingDef [defName="RoyalBed"]</xpath>
             <attribute>Name</attribute>
             <value>RoyalBedBase</value>
         </li>
-        <li class="PatchOperationAdd">
+        <li Class="PatchOperationAdd">
             <xpath>/Defs/ThingDef [defName="RoyalBed"]</xpath>
             <value><uiOrder>2015</uiOrder></value>
         </li>
         </operations>
     </Operation>
     <!-- Slab Bed: Use Slab Double Bed as base, set UI order to same as single Slab Bed -->
-    <Operation class="PatchOperationSequence" MayRequire="Ludeon.RimWorld.Ideology">
+    <Operation Class="PatchOperationSequence" MayRequire="Ludeon.RimWorld.Ideology">
         <operations>
-        <li class="PatchOperationAttributeSet">
+        <li Class="PatchOperationAttributeSet">
             <xpath>/Defs/ThingDef [defName="SlabDoubleBed"]</xpath>
             <attribute>Name</attribute>
             <value>SlabBedBase</value>
         </li>
-        <li class="PatchOperationAdd">
+        <li Class="PatchOperationAdd">
             <xpath>/Defs/ThingDef [defName="SlabDoubleBed"]</xpath>
             <value><uiOrder>2030</uiOrder></value>
         </li>

--- a/1.4/Patches/Generalise_Beds.xml
+++ b/1.4/Patches/Generalise_Beds.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <!-- Makes some some vanilla beds into bases that can be inherited from. Also sets uiOrder. -->
+    <!-- Order: Sleeping Spots (2000), Bedrolls (2005), Normal Beds (2010), Royal Beds (2015), Other Beds (2020), Slab Beds (2030) -->
+    <!-- Sleeping Spot: Already abstracted in Vanilla, no action needed. -->
+    <!-- Bedroll: Use Double Bedroll as base, set UI order -->
+    <Operation class="PatchOperationSequence">
+        <operations>
+        <li class="PatchOperationAttributeSet">
+            <xpath>/Defs/ThingDef [defName="BedrollDouble"]</xpath>
+            <attribute>Name</attribute>
+            <value>BedrollBase</value>
+        </li>
+        <li class="PatchOperationReplace">
+            <xpath>/Defs/ThingDef [defName="Bedroll" or defName="BedrollDouble"]/uiOrder/text()</xpath>
+            <value>2005</value>
+        </li>
+        </operations>
+    </Operation>
+    <!-- Normal Bed: Double Beds are already named for inheritance, just need UI order set same as single bed -->
+    <Operation class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef [defName="DoubleBed"]</xpath>
+        <value><uiOrder>2010</uiOrder></value>
+    </Operation>
+    <!-- Royal Bed: Make into base, set UI order -->
+    <Operation class="PatchOperationSequence">
+        <operations>
+        <li class="PatchOperationAttributeSet">
+            <xpath>/Defs/ThingDef [defName="RoyalBed"]</xpath>
+            <attribute>Name</attribute>
+            <value>RoyalBedBase</value>
+        </li>
+        <li class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef [defName="RoyalBed"]</xpath>
+            <value><uiOrder>2015</uiOrder></value>
+        </li>
+        </operations>
+    </Operation>
+    <!-- Slab Bed: Use Slab Double Bed as base, set UI order to same as single Slab Bed -->
+    <Operation class="PatchOperationSequence" MayRequire="Ludeon.RimWorld.Ideology">
+        <operations>
+        <li class="PatchOperationAttributeSet">
+            <xpath>/Defs/ThingDef [defName="SlabDoubleBed"]</xpath>
+            <attribute>Name</attribute>
+            <value>SlabBedBase</value>
+        </li>
+        <li class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef [defName="SlabDoubleBed"]</xpath>
+            <value><uiOrder>2030</uiOrder></value>
+        </li>
+        </operations>
+    </Operation>
+</Patch>

--- a/1.4/Patches/Generalise_Beds.xml
+++ b/1.4/Patches/Generalise_Beds.xml
@@ -72,8 +72,8 @@
             <xpath>Defs/MemeDef[defName = "PainIsVirtue"]/addDesignators/li[text()="SlabDoubleBed"]</xpath>
             <order>Append</order>
             <value>
+                <li>SlabQuadBed</li> <!-- Needs ordering reversed due to append order -->
                 <li>SlabTripleBed</li>
-                <li>SlabQuadBed</li>
             </value>
         </li>
         </operations>

--- a/1.4/Patches/RoyalTitles_Empire_Patch.xml
+++ b/1.4/Patches/RoyalTitles_Empire_Patch.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+<!-- If any Royal Title requires a Double Bedroll, it is also satisfied by Triple or Quad Bedrolls -->
+<Operation Class="PatchOperationConditional" MayRequire="Ludeon.RimWorld.Royalty">
+	<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things[li="BedrollDouble"]</xpath>
+	<match Class="PatchOperationInsert">
+		<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things/li[text()="BedrollDouble"]</xpath>
+		<order>Append</order>
+		<value>
+			<li>BedrollTriple</li>
+			<li>BedrollQuad</li>
+		</value>
+	</match>
+</Operation>
+
+<!-- If any Royal Title requires a Double Bed, it is also satisfied by Triple or Quad Beds -->
+<Operation Class="PatchOperationConditional" MayRequire="Ludeon.RimWorld.Royalty">
+	<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things[li="DoubleBed"]</xpath>
+	<match Class="PatchOperationInsert">
+		<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things/li[text()="DoubleBed"]</xpath>
+		<order>Append</order>
+		<value>
+			<li>TripleBed</li>
+			<li>QuadBed</li>
+		</value>
+	</match>
+</Operation>
+
+<!-- If any Royal Title requires a Royal Bed, it is also satisfied by Triple, Quad, or Penta Royal Beds -->
+<Operation Class="PatchOperationConditional" MayRequire="Ludeon.RimWorld.Royalty">
+	<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things[li="RoyalBed"]</xpath>
+	<match Class="PatchOperationInsert">
+		<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things/li[text()="RoyalBed"]</xpath>
+		<order>Append</order>
+		<value>
+			<li>TripleRoyalBed</li>
+			<li>QuadRoyalBed</li>
+			<li>PentaRoyalBed</li>
+		</value>
+	</match>
+</Operation>
+
+<!-- If any Royal Title requires a Slab Double Bed, it is also satisfied by Triple or Quad Slab Beds -->
+<Operation Class="PatchOperationConditional" MayRequire="Ludeon.RimWorld.Royalty">
+	<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things[li="SlabDoubleBed"]</xpath>
+	<match Class="PatchOperationInsert">
+		<xpath>Defs/RoyalTitleDef/bedroomRequirements/li[@Class="RoomRequirement_ThingAnyOf"]/things/li[text()="SlabDoubleBed"]</xpath>
+		<order>Append</order>
+		<value>
+			<li>SlabTripleBed</li>
+			<li>SlabQuadBed</li>
+		</value>
+	</match>
+</Operation>
+	
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -6,12 +6,14 @@
 		<li>1.1</li>
 		<li>1.2</li>
 		<li>1.3</li>
+		<li>1.4</li>
 	</supportedVersions>
 	
 	<packageId>Meltup.PolyamoryBeds.Vanilla</packageId>
 	<loadAfter>
 	  <li>Ludeon.RimWorld</li>
       <li>Ludeon.RimWorld.Royalty</li>
+      <li>Ludeon.RimWorld.Ideology</li>
     </loadAfter>
 	
 	<description>More beds for your polyamorous pawns!
@@ -28,9 +30,11 @@ Includes full built-in support for [JPT] Soft Warm Beds and Nano Repair Tech!
  
 Known issues
      - Some other mods may interfere with game's miniaturisation mechanics thus making it possible to install/uninstall sleeping spots (and you may get also get messages about 'Outdoor penalty' when placing sleeping spots outside).
-Solution: move this mod higher up in the loading order.
-     - When three or more pawns share the same bed, the bedroom looses personal tags. That is a problem for jealous pawns and pawns with royal titles as they specifically require personal bedrooms to be satisfied.
-Solution: fight the Empire! Or consider that honour forbids pawns with titles to share bed with more than one person at a time.
+Solution: move this mod above those mods.
+     - Modded Royal Titles may not recognise larger beds as suitable substitutes for double beds of that type.
+Solution: move this mod below the mod adding the titles.
+     - Pawns with a Spouse-Only Physical Love precept cannot sleep with multiple spouses at the same time unless their spouses are also married to each other.
+Solution: this is Vanilla behaviour outside the scope of this mod. [SIC] Co-Spousal Relations is one mod that addresses this.
  
 Please report any problems and/or inconsequences!
 	</description>


### PR DESCRIPTION
Triple/Quad Sleeping spots should inherit from SleepingSpotBase, like Double Sleeping Spots, rather than duplicating values. This means that if Sleeping Spots are patched (changing stats, designation category, etc.), either in a mod or officially, it will affect all sleeping spots equally.